### PR TITLE
language added: zh-cn.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import fi from './translations/fi';
 import hi from './translations/hi';
 import hu from './translations/hu';
 import se from './translations/se';
+import zh_cn from './translations/zh-cn';
 
 const translations = {
   de: de,
@@ -11,7 +12,8 @@ const translations = {
   fi: fi,
   hi: hi,
   hu: hu,
-  se: se
+  se: se,
+  zh_cn: zh_cn
 };
 
 export {
@@ -20,7 +22,8 @@ export {
   fi,
   hi,
   hu,
-  se
+  se,
+  zh_cn
 }
 
 export default translations;

--- a/src/translations/zh-cn.ts
+++ b/src/translations/zh-cn.ts
@@ -1,0 +1,37 @@
+// prettier-ignore
+const zh_cn = {
+    translation: {
+      'Cancel': '取消',
+      'Categories': '类别',
+      'Create category': '创建类别',
+      'Create new classifier': '新建分类器',
+      'Delete category': '删除类别',
+      'Delete images': '删除图片',
+      'Description': '注释',
+      'Edit': '编辑',
+      'Edit category': '编辑类别',
+      'Help': '帮助',
+      'Hide other categories': '隐藏其他类别',
+      'Hide sidebar': '隐藏边栏',
+      'Import images': '导入图片',
+      'Logo': '徽标',
+      'Model': '模型',
+      'Open classifier': '打开分类器',
+      'Open example classifier': '打开示例分类器',
+      'Open weights': '打开权重',
+      'Open': '打开',
+      'Run classifier': '运行分类器',
+      'Save annotations and predictions': '保存标注和预测',
+      'Save classifier': '保存分类器',
+      'Save weights': '保存权重',
+      'Save': '保存',
+      'Search images': '搜索图片',
+      'Send feedback': '发送反馈',
+      'Settings': '设置',
+      'Show sidebar': '显示边栏',
+      'Unknown': '未知'
+    }
+  };
+  
+  export default zh_cn;
+  


### PR DESCRIPTION
Added translation of mandarin.
Note that according to [ISO language codes](https://www.andiamo.co.uk/resources/iso-language-codes/), mandarin is identified as `zh-cn`, but this commit uses `zh_cn` for variables, and `zh-cn` for file names. Mind the difference if there are problems.